### PR TITLE
Fix BPF verifier error in `dirt-ebpf`

### DIFF
--- a/dirt-ebpf/src/main.rs
+++ b/dirt-ebpf/src/main.rs
@@ -157,17 +157,14 @@ fn try_uretprobe_handler(ctx: RetProbeContext) -> Result<u32, u32> {
 
             // Check the source path first.
             get_share_name(&(*event).src_path, &mut *share_name_buf)?;
-            let src_whitelisted = (*(&raw mut WHITELIST)).get(&*share_name_buf).is_some();
-
-            // If it's a rename event, check the target path.
-            let mut tgt_whitelisted = false;
-            if matches!((*event).event, EventType::Rename) {
-                get_share_name(&(*event).tgt_path, &mut *share_name_buf)?;
-                tgt_whitelisted = (*(&raw mut WHITELIST)).get(&*share_name_buf).is_some();
-            }
-
-            if src_whitelisted || tgt_whitelisted {
+            if (*(&raw mut WHITELIST)).get(&*share_name_buf).is_some() {
                 let _ = (*(&raw mut EVENTS)).output(&*event, 0);
+            } else if matches!((*event).event, EventType::Rename) {
+                // If it's a rename event and source wasn't whitelisted, check the target path.
+                get_share_name(&(*event).tgt_path, &mut *share_name_buf)?;
+                if (*(&raw mut WHITELIST)).get(&*share_name_buf).is_some() {
+                    let _ = (*(&raw mut EVENTS)).output(&*event, 0);
+                }
             }
         }
     }


### PR DESCRIPTION
This change fixes a BPF verifier error `R1 pointer |= pointer prohibited` in `dirt-ebpf/src/main.rs`. The error was caused by the compiler optimizing a logical OR (`||`) between two `Option::is_some()` calls (from BPF map lookups) into a bitwise OR operation on pointers. I replaced the logical OR with explicit `if` and `else if` branching to avoid this optimization and ensure verifier-friendly bytecode. This also adds a minor optimization by short-circuiting the whitelist check.

---
*PR created automatically by Jules for task [16665459699657981224](https://jules.google.com/task/16665459699657981224) started by @bobbintb*